### PR TITLE
Remove extra keys from metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,16 +1,3 @@
-name: flannel
-summary: charm-build layer for flannel
-maintainers:
-    - Charles Butler <charles.butler@canonical.com>
-description: |
-  A minimalist charm layer for use with charm build,
-  powered by the reactive framework to enable flannel SDN
-tags:
-  - containers
-  - networking
-series:
-  - trusty
-subordinate: false
 requires:
   etcd:
     interface: etcd


### PR DESCRIPTION
middle layers should not have a fully-formed metadata, its adding
extraneous data to top-layer charms.
