### PR TITLE
Make graph location conform to naming conventions

### DIFF
--- a/templates/bootstrap-docker.defaults
+++ b/templates/bootstrap-docker.defaults
@@ -1,4 +1,4 @@
 # THIS FILE IS UNDER THE CONTROL OF JUJU
 # MANUAL EDITS WILL NOT PERSIST
 
-DOCKER_OPTS="-H unix://var/run/bootstrap-docker.sock -p /var/run/bootstrap-docker.pid --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/docker-bootstrap"
+DOCKER_OPTS="-H unix://var/run/bootstrap-docker.sock -p /var/run/bootstrap-docker.pid --iptables=false --ip-masq=false --bridge=none --graph=/var/lib/bootstrap-docker"


### PR DESCRIPTION
Every mention of "docker-bootstrap" has been renamed to
bootstrap-docker, this should be the last squash of this nomenclature
