### PR TITLE
Detect the default interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Flannel Charm Layer
 
-A minimal layer intended to be "mixed in" with the [Docker Layer](http://github.com/juju-solutions/layer-docker)
+A minimal layer intended to be "mixed in" with the 
+[Docker Layer](http://github.com/juju-solutions/layer-docker)
 to provide Flannel based Overlay Networking to Docker Container infrastructure
 
 This will probably go away into a more generic libnetwork abstraction when
 docker 1.9 launches.
+
+## Configuration
+
+**iface** The interface to configure the flannel SDN binding. If this value is
+empty string or undefined the code will attempt to find the default network 
+adapter similar to the following command:  
+```bash 
+route | grep default | head -n 1 | awk {'print $8'}
+```

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,11 @@
 options:
   iface:
     type: string
-    default: eth0
+    default: ""
     description: |
-      Interface to bind flannel overlay networking to. Defaults to eth0.
+      The interface to bind flannel overlay networking. The default value is
+      the result of running the following command: 
+      `route | grep default | head -n 1 | awk {'print $8'}`.
   cidr:
     type: string
     default: 10.1.0.0/16

--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -20,6 +20,7 @@ from charmhelpers.core import unitdata
 
 import charms.apt
 import os
+import subprocess
 import time
 
 
@@ -130,7 +131,7 @@ def run_flannel(etcd):
         iface = get_default_interface()
         # When detection not successful, print message and return.
         if not iface:
-            status_set('blocked', "Interface detection failed. " 
+            status_set('blocked', "Interface detection failed. "
                        "Set charm's iface config option.")
             return
     # Add additional key/values to the context dictionary.
@@ -228,10 +229,10 @@ def get_default_interface():
     # The route command lists the default interfaces.
     # Destination    Gateway        Genmask      Flags Metric Ref    Use Iface
     # default        10.128.0.1     0.0.0.0      UG    0      0        0 ens4
-    output = subprocess.check_output(cmd)
+    output = subprocess.check_output(cmd).decode('utf8')
     # Parse each onen of the lines.
     for line in output.split('\n'):
         # When the line contains 'default'.
         if 'default' in line:
             # The last column is the network interface.
-            return line.split(' ')[-1])
+            return line.split(' ')[-1]


### PR DESCRIPTION
With xenial the interface is `ens4` the code was expecting `eth0` and the assumption breaks the configuration of the flannel interface.

Changed the default behavior to attempt to detect the default interface when the `iface` configuration option is None or "".

Take that !

edit: closes #16 
