### PR TITLE
Adds immutable config fix for bootstrap-daemon

### DIFF
--- a/reactive/flannel.py
+++ b/reactive/flannel.py
@@ -177,7 +177,8 @@ def reconfigure_docker_for_sdn():
 
 
 @when_any('config.cidr.changed', 'config.etcd_image.changed',
-          'config.flannel_image.changed', 'config.iface.changed')
+          'config.flannel_image.changed', 'config.iface.changed',
+          'config.http_proxy.changed', 'config.https_proxy.changed')
 def reconfigure_flannel_network():
     ''' When the user changes the cidr, we need to reconfigure the
     backing etcd_store, and re-launch the flannel docker container.'''


### PR DESCRIPTION
Additionally:
Patching a bug introduced in 4623e361
- The workload docker daemon was getting consistently reset. This is
  problematic, as it interrupts the workloads running. An unintended
  side effect.

The charm should now only re-render the template, and re-load the
systctl definition, along with recycling the bootstrap-docker daemon.
This has less impact on running workloads than interrupting the primary
workload bridge.
